### PR TITLE
Fix hot_temperature taking value of cold_temperature

### DIFF
--- a/custom_components/check_weather/binary_sensor.py
+++ b/custom_components/check_weather/binary_sensor.py
@@ -261,5 +261,5 @@ class CheckWeatherSensor(BinarySensorEntity):
         self._attr_precipitation = precipitation
         self._attr_strong_wind = strong_wind
         self._attr_cold_temperature = cold_temperature
-        self._attr_hot_temperature = cold_temperature
+        self._attr_hot_temperature = hot_temperature
         self._attr_time = bad_weather_time


### PR DESCRIPTION
I noticed my sensor showing both `hot_temperature` and `cold_temperature` to be true although todays temperature range is barely 3°C.
So I went to investigate and I think I found the culprit :-)

Thanks for the integration, hope this is right and can be merged!