### PR TITLE
Make precipitation checks work with probabilities.

### DIFF
--- a/custom_components/check_weather/binary_sensor.py
+++ b/custom_components/check_weather/binary_sensor.py
@@ -20,6 +20,7 @@ from homeassistant.components.weather import (
     ATTR_CONDITION_SNOWY_RAINY,
     ATTR_FORECAST_CONDITION,
     ATTR_FORECAST_PRECIPITATION,
+    ATTR_FORECAST_PRECIPITATION_PROBABILITY,
     ATTR_FORECAST_TEMP,
     ATTR_FORECAST_TIME,
     ATTR_FORECAST_WIND_SPEED,
@@ -228,7 +229,15 @@ class CheckWeatherSensor(BinarySensorEntity):
 
             if forecast.get(ATTR_FORECAST_CONDITION) in BAD_CONDITIONS:
                 bad_condition = forecast.get(ATTR_FORECAST_CONDITION)
-            if forecast.get(ATTR_FORECAST_PRECIPITATION) > prec_threshold:
+            if ATTR_FORECAST_PRECIPITATION in forecast:
+                if forecast.get(ATTR_FORECAST_PRECIPITATION) > prec_threshold:
+                    precipitation = True
+            elif (
+                (prec_prob := forecast.get(ATTR_FORECAST_PRECIPITATION_PROBABILITY))
+                is not None
+                # Probabilities are integers (0-100) not floats (0.0-1.0).
+                and prec_prob * 100 > prec_threshold
+            ):
                 precipitation = True
             if forecast.get(ATTR_FORECAST_WIND_SPEED) > wind_threshold:
                 strong_wind = True


### PR DESCRIPTION
Some weather integrations (For example, https://www.home-assistant.io/integrations/nws/) don't set a `precipitation` attribute in the forecasts, but instead set a `precipitation_probability` attribute. In these cases, the integration will currently fail with a `TypeError` trying to compare `None` to a `float`. This fixes that problem by first checking whether the forecast has a `precipitation` attribute and falls back to `precipitation_probability` if missing.